### PR TITLE
Remove the .j2. extension from templates when generating the scripts

### DIFF
--- a/generate_scripts.sh
+++ b/generate_scripts.sh
@@ -13,5 +13,5 @@ fi
 
 for f in $(ls templates) ; do
   echo "Converting templates/$f to scripts/$f:"
-  $JINJA templates/$f config.yaml > scripts/$f
+  $JINJA templates/$f config.yaml > scripts/${f//[.]j2[.]/.}
 done


### PR DESCRIPTION
Fix #1