### PR TITLE
Use variables whenever possible for hotfix.j2.yaml

### DIFF
--- a/templates/hotfix.j2.yaml
+++ b/templates/hotfix.j2.yaml
@@ -5,6 +5,6 @@
       name: tripleo-modify-image
     vars:
       tasks_from: rpm_install.yml
-      source_image: registry.access.redhat.com/rhosp13/openstack-nova-compute:{{ '{{' }} image_tag {{ '}}' }}
+      source_image: {{ container_registry }}/{{ container_image_name }}:{{ '{{' }} image_tag {{ '}}' }}
       rpms_path: /tmp/hotfix/
       modified_append_tag: -hotfix-{{ bugzilla_number }}


### PR DESCRIPTION
A few values are currently hardcoded, but the corresponding
variables are defined and can be used.

Fixes #3