### PR TITLE
Clone the ansible role from the main site (opendev.org)

### DIFF
--- a/templates/generate_hotfix.j2.sh
+++ b/templates/generate_hotfix.j2.sh
@@ -7,7 +7,7 @@ fi
 
 : ${IMAGE_TAG:=$(docker images | grep "{{ container_registry }}/{{ container_image_name }}" | awk 'NR==1{print $2}')}
 
-git clone https://github.com/openstack/ansible-role-tripleo-modify-image
+git clone https://opendev.org/openstack/ansible-role-tripleo-modify-image
 mkdir ansible-role-tripleo-modify-image/roles
 ln -s $PWD/ansible-role-tripleo-modify-image $PWD/ansible-role-tripleo-modify-image/roles/tripleo-modify-image
 rm -Rf /tmp/hotfix


### PR DESCRIPTION
opendev.org is the canonical location, github is just a mirror.